### PR TITLE
Added support for OSGi by adding the maven bundle plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,4 +22,39 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.5.4</version>
+        <configuration>
+          <excludeDependencies>true</excludeDependencies>
+          <instructions>
+            <Export-Package>{local-packages}</Export-Package>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Hi Jeremy,

thanks for maintaining the jbcrypt library here.

I am currently working on a project where we rely on OSGi and where we want to use jBCrypt as well. Unfortunately jBCrypt is currently not supporting OSGi, meaning there are no bundle headers in the manifest file. I added the required plugin configuration to the maven pom file. If you are interested I would be happy to see this change included. Maybe there are one or two other people in the world who also still work on OSGi and could benefit from this ;-)

Thanks!
Patrick
