### PR TITLE
Fixed invalid salt version exception on checkpw

### DIFF
--- a/src/main/java/org/mindrot/BCrypt.java
+++ b/src/main/java/org/mindrot/BCrypt.java
@@ -662,7 +662,7 @@ public class BCrypt {
 			off = 3;
 		else {
 			minor = salt.charAt(2);
-			if (minor != 'a' || salt.charAt(3) != '$')
+			if (minor != 'y' || salt.charAt(3) != '$')
 				throw new IllegalArgumentException ("Invalid salt revision");
 			off = 4;
 		}


### PR DESCRIPTION
Yeah, hashes have y in them, not sure if they had an a in the past but now it's different, I guess, works all the same only this time my application doesn't crash.
