### PR TITLE
add license title

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 jBCrypt is subject to the following license:
 
 /*
+ * ISC License
+ *
  * Copyright (c) 2006 Damien Miller <djm@mindrot.org>
  *
  * Permission to use, copy, modify, and distribute this software for any


### PR DESCRIPTION
It's not legally required, but it's useful metadata, and part of the recommended license template text:
- http://choosealicense.com/licenses/isc/
- https://opensource.org/licenses/isc-license
- http://spdx.org/licenses/ISC.html#licenseText
