### PR TITLE
Remove unnecessary try/catch blocks

### DIFF
--- a/src/main/java/org/mindrot/BCrypt.java
+++ b/src/main/java/org/mindrot/BCrypt.java
@@ -15,7 +15,7 @@ package org.mindrot;
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import java.io.UnsupportedEncodingException;
-
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 
 /**
@@ -447,7 +447,7 @@ public class BCrypt {
 		byte c1, c2, c3, c4, o;
 
 		if (maxolen <= 0)
-			throw new IllegalArgumentException ("Invalid maxolen");
+			throw new IllegalArgumentException("Invalid maxolen");
 
 		while (off < slen - 1 && olen < maxolen) {
 			c1 = char64(s.charAt(off++));
@@ -673,11 +673,7 @@ public class BCrypt {
 		rounds = Integer.parseInt(salt.substring(off, off + 2));
 
 		real_salt = salt.substring(off + 3, off + 25);
-		try {
-			passwordb = (password + (minor >= 'a' ? "\000" : "")).getBytes("UTF-8");
-		} catch (UnsupportedEncodingException uee) {
-			throw new AssertionError("UTF-8 is not supported");
-		}
+		passwordb = (password + (minor >= 'a' ? "\000" : "")).getBytes(StandardCharsets.UTF_8);
 
 		saltb = decode_base64(real_salt, BCRYPT_SALT_LEN);
 
@@ -761,13 +757,9 @@ public class BCrypt {
 	public static boolean checkpw(String plaintext, String hashed) {
 		byte hashed_bytes[];
 		byte try_bytes[];
-		try {
-			String try_pw = hashpw(plaintext, hashed);
-			hashed_bytes = hashed.getBytes("UTF-8");
-			try_bytes = try_pw.getBytes("UTF-8");
-		} catch (UnsupportedEncodingException uee) {
-			return false;
-		}
+		String try_pw = hashpw(plaintext, hashed);
+		hashed_bytes = hashed.getBytes(StandardCharsets.UTF_8);
+		try_bytes = try_pw.getBytes(StandardCharsets.UTF_8);
 		if (hashed_bytes.length != try_bytes.length)
 			return false;
 		byte ret = 0;


### PR DESCRIPTION
As an alternative to referring to the charset by name, which throws a checked exception, there is the `StandardCharsets` class which contains the actual `Charset` instance you're looking for.