### PR TITLE
Support 2b and 2y hashes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBCrypt
-jBCrypt is an implementation the OpenBSD Blowfish password hashing algorithm,
-as described in ["A Future-Adaptable Password
+jBCrypt is an implementation of the OpenBSD Blowfish password hashing
+algorithm, as described in ["A Future-Adaptable Password
 Scheme"](http://www.openbsd.org/papers/bcrypt-paper.ps) by Niels Provos and
 David Mazieres.  
 

--- a/src/main/java/org/mindrot/BCrypt.java
+++ b/src/main/java/org/mindrot/BCrypt.java
@@ -731,16 +731,23 @@ public class BCrypt {
 	 * @param log_rounds	the log2 of the number of rounds of
 	 * hashing to apply - the work factor therefore increases as
 	 * 2**log_rounds.
+	 * @param minor		the minor revision of the algorithm to use;
+	 * the latest revision is 'b'. Other accepted revisions are 'a'
+	 * and 'y'.
 	 * @param random		an instance of SecureRandom to use
 	 * @return	an encoded salt value
 	 */
-	public static String gensalt(int log_rounds, SecureRandom random) {
+	public static String gensalt(int log_rounds, char minor, SecureRandom random) {
 		StringBuffer rs = new StringBuffer();
 		byte rnd[] = new byte[BCRYPT_SALT_LEN];
 
 		random.nextBytes(rnd);
 
-		rs.append("$2a$");
+		if (minor != 'a' && minor != 'b' && minor != 'y')
+			throw new IllegalArgumentException(
+				"unsupported minor revision: " + minor);
+
+		rs.append("$2" + minor + "$");
 		if (log_rounds < 10)
 			rs.append("0");
 		if (log_rounds > 30) {
@@ -758,10 +765,44 @@ public class BCrypt {
 	 * @param log_rounds	the log2 of the number of rounds of
 	 * hashing to apply - the work factor therefore increases as
 	 * 2**log_rounds.
+	 * @param random		an instance of SecureRandom to use
+	 * @return	an encoded salt value
+	 */
+	public static String gensalt(int log_rounds, SecureRandom random) {
+		/* Support for b-hashes was added on Jan 22, 2020. The
+		 * default revision of generated salts should arguably
+		 * be cahgned to 'b' after some reasonable transition
+		 * period. (A year?) */
+		return gensalt(log_rounds, 'a', random);
+	}
+
+	/**
+	 * Generate a salt for use with the BCrypt.hashpw() method
+	 * @param log_rounds	the log2 of the number of rounds of
+	 * hashing to apply - the work factor therefore increases as
+	 * 2**log_rounds.
+	 * @param minor		the minor revision of the algorithm to use;
+	 * the latest revision is 'b'. Other accepted revisions are 'a'
+	 * and 'y'.
+	 * @return	an encoded salt value
+	 */
+	public static String gensalt(int log_rounds, char minor) {
+		return gensalt(log_rounds, minor, new SecureRandom());
+	}
+
+	/**
+	 * Generate a salt for use with the BCrypt.hashpw() method
+	 * @param log_rounds	the log2 of the number of rounds of
+	 * hashing to apply - the work factor therefore increases as
+	 * 2**log_rounds.
 	 * @return	an encoded salt value
 	 */
 	public static String gensalt(int log_rounds) {
-		return gensalt(log_rounds, new SecureRandom());
+		/* Support for b-hashes was added on Jan 22, 2020. The
+		 * default revision of generated salts should arguably
+		 * be cahgned to 'b' after some reasonable transition
+		 * period. (A year?) */
+		return gensalt(log_rounds, 'a');
 	}
 
 	/**

--- a/src/main/java/org/mindrot/BCrypt.java
+++ b/src/main/java/org/mindrot/BCrypt.java
@@ -664,7 +664,7 @@ public class BCrypt {
 			if (salt.charAt(3) != '$')
 				throw new IllegalArgumentException ("Invalid salt revision");
 			minor = salt.charAt(2);
-			if (minor < 'a' || minor > 'b')
+			if (minor != 'a' && minor != 'b' && minor != 'y')
 				throw new IllegalArgumentException ("Invalid salt revision");
 			off = 4;
 		}


### PR DESCRIPTION
This adds support for 2b and 2y hash revisions.

It is perhaps worthy to note that jBCrypt's support for 2a hashes is incorrect, as it should mimic the bug in the OpenBSD implementation that spawned the 2b hash, that is, wrapping the password length at 256. Since it's probably mostly used in "private" systems where it doesn't interact with other implementations, it's probably best to leave the 2a support as is, so as to not break current hashes, but it is nevertheless technically incorrect.

Also, jBCrypt *should* generate 2b hashes in `gensalt`, but that could cause problems where several systems that use the same password database might be at different versions. OpenBSD solved this by first adding support for 2b hashes, and then half a year later also generating them by default. Arguably, jBCrypt should do the same thing.

Finally, 2y hashes should be identical to 2b hashes, so I added support for those as well, even though they're only used in the PHP implementation of bcrypt. I noticed there were a number of forks that did nothing but add 2y-hash support, so I figured why not add it. I'd like to note that 2y is *not* the same as 2x, since 2x indicates a bug in a previous PHP version of bcrypt, that I don't have any personal reason to track down and recreate.