### PR TITLE
StringBuffer -> StringBuilder and other modernizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+jbcrypt.iml
+target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ mvn -U clean versions:display-dependency-updates
 ```
  - Upgraded Junit from 3.8.1 to 4.13.1 (the latest).
  - Added Changelog file
+ - Added .gitignore to avoid checking in Intellij or Maven files.
 
 ## 0.4(.0) jeremyh/jBCrypt taken from djmdjm/jBCrypt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+
+## 0.4.1 "StringBuilder"
+ - Replaced StringBuffer with StringBuilder because it is more efficient.
+ Efficiency is important because of the "work" required by this algorithm.
+ - Added maven.compiler.source/target = 1.8 since that's the earliest still-maintained version of Java.
+ - Added Maven enforcer plugin to be sure we are building with the latest defaults for Maven.
+ Use the following to check plugin and dependency versions:
+ ```text
+mvn -U clean versions:display-plugin-updates
+mvn -U clean versions:display-dependency-updates
+```
+ - Upgraded Junit from 3.8.1 to 4.13.1 (the latest).
+ - Added Changelog file
+
+## 0.4(.0) jeremyh/jBCrypt taken from djmdjm/jBCrypt
+
+This is an alternative distribution of jBCrypt. It has been packaged to ease use in existing applications — especially those using Apache Maven.
+
+The code is unchanged from the original jBCrypt 0.4, however:
+
+The classes have been moved to a java package to avoid pollution of the global namespace. org.mindrot was chosen to reflect their original origin.
+The JBCrypt class javadoc has been changed to version 0.4. The official package incorrectly contains 0.2 as the stated version.
+A pom.xml file has been added for use with Maven

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ The code is unchanged from the original jBCrypt 0.4, however:
 
 Install it to your local Maven repository:
 
-	mvn clean javadoc:jar source:jar install
+	mvn clean source:jar install
 
 Use it in your project by adding the following to your project *pom.xml*:
 
         <dependency>
             <groupId>org.mindrot</groupId>
             <artifactId>jbcrypt</artifactId>
-            <version>0.3</version>
+            <version>0.4.1</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,21 +4,48 @@
 
   <groupId>org.mindrot</groupId>
   <artifactId>jbcrypt</artifactId>
-  <version>0.4</version>
+  <version>0.4.1</version>
   <packaging>jar</packaging>
 
   <name>jbcrypt</name>
   <url>http://www.mindrot.org/projects/jBCrypt</url>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.6.0,)</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/mindrot/BCrypt.java
+++ b/src/main/java/org/mindrot/BCrypt.java
@@ -59,7 +59,7 @@ import java.security.SecureRandom;
  * 10, and the valid range is 4 to 30.
  *
  * @author Damien Miller
- * @version 0.4
+ * @version 0.4.1
  */
 public class BCrypt {
 	// BCrypt parameters
@@ -388,7 +388,7 @@ public class BCrypt {
 	private static String encode_base64(byte d[], int len)
 		throws IllegalArgumentException {
 		int off = 0;
-		StringBuffer rs = new StringBuffer();
+		StringBuilder rs = new StringBuilder();
 		int c1, c2;
 
 		if (len <= 0 || len > d.length)
@@ -441,7 +441,7 @@ public class BCrypt {
 	 */
 	private static byte[] decode_base64(String s, int maxolen)
 		throws IllegalArgumentException {
-		StringBuffer rs = new StringBuffer();
+		StringBuilder rs = new StringBuilder();
 		int off = 0, slen = s.length(), olen = 0;
 		byte ret[];
 		byte c1, c2, c3, c4, o;
@@ -654,7 +654,7 @@ public class BCrypt {
 		byte passwordb[], saltb[], hashed[];
 		char minor = (char)0;
 		int rounds, off = 0;
-		StringBuffer rs = new StringBuffer();
+		StringBuilder rs = new StringBuilder();
 
 		if (salt.charAt(0) != '$' || salt.charAt(1) != '2')
 			throw new IllegalArgumentException ("Invalid salt version");
@@ -712,7 +712,7 @@ public class BCrypt {
 	 * @return	an encoded salt value
 	 */
 	public static String gensalt(int log_rounds, SecureRandom random) {
-		StringBuffer rs = new StringBuffer();
+		StringBuilder rs = new StringBuilder();
 		byte rnd[] = new byte[BCRYPT_SALT_LEN];
 
 		random.nextBytes(rnd);


### PR DESCRIPTION
Thank you for adding a Maven project to https://github.com/djmdjm/jBCrypt

BCrypt needs to be efficient because it relies on "work" for security.  If someone else can make a faster version, they can break your encryption more cheaply than you can make it.  StringBuilder is a more efficient replacement for StringBuffer, so I wanted to make that change.

Using supported software is considered more secure than unsupported, so I moved us up to Java 8.

Added the Maven Enforcer plugin to make checking versions easier in the future.

Upgraded to the latest JUnit.

Added `CHANGELOG.md` and `.gitignore` files.

Basically I wanted to update things as securely as possible while changing as little as possible.  What do you think?